### PR TITLE
Adding asan flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ else
   BOOST_PYTHON  = boost_python
 endif
 
-CFLAGS  += -ggdb -fPIC -Wall $$($(PYTHON_CONFIG) --includes) \
+CFLAGS  += -ggdb -fPIC -Wall -fsanitize=address -fno-omit-frame-pointer -static-libasan $$($(PYTHON_CONFIG) --includes) \
 	   -Ibluez $$(pkg-config --cflags glib-2.0)
 
 CFLAGS  += -DVERSION='"5.25"'


### PR DESCRIPTION
We are statically linking ASAN. Tested compilation using gcc 4.8 and verified the size. It works on x86_64